### PR TITLE
Add PROJECTS_PATHS to paths that can be jumped to, use function for completion

### DIFF
--- a/completions/pj.fish
+++ b/completions/pj.fish
@@ -1,2 +1,1 @@
-complete --command pj --no-files --arguments='(find $PROJECT_PATHS -mindepth 1 -maxdepth 1 -exec basename "{}" \;)'
-
+complete --command pj --no-files --arguments=(__project_basenames)

--- a/functions/pj.fish
+++ b/functions/pj.fish
@@ -18,7 +18,7 @@ function pj --description "Jump to a project"
     echo 'Usage: pj [open] [PROJECT]'
 
   else if test $argv[1] = "open"
-    set -l target (find $PROJECT_PATHS -mindepth 1 -maxdepth 1 -name $argv[2] | head -n 1)
+    set -l target (find $PROJECT_PATHS -maxdepth 1 -name $argv[2] | head -n 1)
 
     if test -n "$target"
       eval $EDITOR $target
@@ -28,7 +28,7 @@ function pj --description "Jump to a project"
     end
 
   else
-    set -l target (find $PROJECT_PATHS -mindepth 1 -maxdepth 1 -name $argv[1] | head -n 1)
+    set -l target (find $PROJECT_PATHS -maxdepth 1 -name $argv[1] | head -n 1)
 
     if test -n "$target"
       cd $target

--- a/functions/pj.fish
+++ b/functions/pj.fish
@@ -21,6 +21,7 @@ function pj --description "Jump to a project"
     set -l target (find $PROJECT_PATHS -maxdepth 1 -name $argv[2] | head -n 1)
 
     if test -n "$target"
+      cd $target
       eval $EDITOR $target
     else
       echo "No such project: $argv[2]"

--- a/functions/pj.fish
+++ b/functions/pj.fish
@@ -39,3 +39,16 @@ function pj --description "Jump to a project"
   end
 end
 
+function __project_basenames --description "List of project basenames"
+  set -l project_basenames
+
+  for pp in $PROJECT_PATHS
+    set -a project_basenames (basename $pp)
+
+    for project in (ls -d $pp/*/)
+      set -a project_basenames (basename $project)
+    end
+  end
+
+  echo $project_basenames
+end


### PR DESCRIPTION
* Sometimes its nice to be able to jump to the `PROJECT_PATHS` themselves. This PR adds the actual `PROJECT_PATHS` to the completion list
* For the completion `pj` command, I've replaced the `find` command with a new function `__pj_basenames` which no longer uses the `find` command, which I find to be faster
* also tweaks `find` command in the `pj` function so that the `PROJECT_PATHS` can be jumped to
* `pj open` now changes directory before opening `$EDITOR`