### PR TITLE
Fix warning on directory without sub directories

### DIFF
--- a/functions/pj.fish
+++ b/functions/pj.fish
@@ -48,8 +48,8 @@ function __project_basenames --description "List of project basenames"
 
     if test -n "$contains_files"
       set -a project_basenames (basename $pp)
-      for project in (ls -d $pp/*/)
-        set -a project_basenames (basename $project)
+      for project in (find "$pp" -type d -maxdepth 1 -mindepth 1 -not -name '.*' -exec basename {} \;)
+        set -a project_basenames $project
       end
     end
   end


### PR DESCRIPTION
There's autocomplete warning if a projects directory contains only files but no subdirectories. This commit fixes the warning.

Example of such directory:
<img width="307" alt="Screenshot 2025-03-10 at 14 29 12" src="https://github.com/user-attachments/assets/de93f48d-3edf-439c-a1c6-4f7667925645" />
