### PR TITLE
Fix find warning re order of arguments

### DIFF
--- a/functions/pj.fish
+++ b/functions/pj.fish
@@ -48,7 +48,7 @@ function __project_basenames --description "List of project basenames"
 
     if test -n "$contains_files"
       set -a project_basenames (basename $pp)
-      for project in (find "$pp" -type d -maxdepth 1 -mindepth 1 -not -name '.*' -exec basename {} \;)
+      for project in (find "$pp" -maxdepth 1 -mindepth 1 -type d -not -name '.*' -exec basename {} \;)
         set -a project_basenames $project
       end
     end


### PR DESCRIPTION
As of a recent update, find gives a warning because in one of the find calls in pj, `-mindepth`/`-maxdepth` are used before `-type d` (and other args).  This one-line change fixes that.