### PR TITLE
Add support for project names with spaces

### DIFF
--- a/completions/pj.fish
+++ b/completions/pj.fish
@@ -1,1 +1,8 @@
-complete --command pj --no-files --arguments=(__project_basenames)
+# Complete 'open' subcommand when no subcommand given yet
+complete --command pj --no-files --condition '__fish_is_first_arg' --arguments 'open' --description 'Open project in editor'
+
+# Complete project names as first argument (no subcommand)
+complete --command pj --no-files --condition '__fish_is_first_arg' --arguments '(__project_basenames)'
+
+# Complete project names after 'open' subcommand
+complete --command pj --no-files --condition '__fish_seen_subcommand_from open' --arguments '(__project_basenames)'

--- a/functions/pj.fish
+++ b/functions/pj.fish
@@ -18,18 +18,18 @@ function pj --description "Jump to a project"
     echo 'Usage: pj [open] [PROJECT]'
 
   else if test $argv[1] = "open"
-    set -l target (find $PROJECT_PATHS -maxdepth 1 -name $argv[2] | head -n 1)
+    set -l target (find $PROJECT_PATHS -maxdepth 1 -name "$argv[2]" | head -n 1)
 
     if test -n "$target"
-      cd $target
-      eval $EDITOR $target
+      cd "$target"
+      $EDITOR "$target"
     else
       echo "No such project: $argv[2]"
       return 1
     end
 
   else
-    set -l target (find $PROJECT_PATHS -maxdepth 1 -name $argv[1] | head -n 1)
+    set -l target (find $PROJECT_PATHS -maxdepth 1 -name "$argv[1]" | head -n 1)
 
     if test -n "$target"
       cd $target
@@ -54,5 +54,5 @@ function __project_basenames --description "List of project basenames"
     end
   end
 
-  echo $project_basenames
+  printf '%s\n' $project_basenames
 end


### PR DESCRIPTION
- Autocompletion now works correctly with project names that include spaces.
- Add "open" command to completion
- Fix pj open for projects with spaces in their names